### PR TITLE
Add remaining community health files for the org

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+<!-- Use https://mozillascience.github.io/working-open-workshop/contributing for further reference & learn about writing better contributing guidelines -->
+
+# Contributing to developersIndia-maintained projects
+
+A big welcome and thank you for considering contributing to developersIndia-maintained Free & Open-Source Software (FOSS) projects! It’s people like you that make it a reality for users in our community.
+
+Reading and following these guidelines will help us make the contribution process easy and effective for everyone involved. It also communicates that you agree to respect the time of the developers managing and developing these open source projects. In return, we will reciprocate that respect by addressing your issue, assessing changes, and helping you finalize your pull requests.
+
+## Quicklinks
+
+* [Code of Conduct](#code-of-conduct)
+* [Getting Started](#getting-started)
+  * [Issues](#issues)
+    * [Pull Requests](#pull-requests)
+* [Getting Help](#getting-help)
+
+## Code of Conduct
+
+We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/.github//blob/main/CODE_OF_CONDUCT.md).
+
+## Getting Started
+
+Contributions are made to this repo via Issues and Pull Requests (PRs). A few general guidelines that cover both:
+
+* To report security vulnerabilities, please refer to our [Security Policy](https://github.com/developersIndia/.github/blob/main/SECURITY.md) which is monitored by our core team.
+
+* Search for existing Issues and PRs before creating your own.
+
+* We work hard to make sure issues are handled in a timely manner but, depending on the impact, it could take a while to investigate the root cause. A friendly ping in the comment thread to the submitter or a contributor can help draw attention if your issue is blocking.
+
+* If you've never contributed before, see ["A First Timers Guide to an Open Source Project"](https://auth0.com/blog/a-first-timers-guide-to-an-open-source-project/) article by [Auth0](https://auth0.com) for resources and tips on how to get started.
+
+### Issues
+
+Issues should be used to report problems with the library, request a new feature, or to discuss potential changes before a PR is created. When you create a new Issue, a template will be loaded that will guide you through collecting and providing the information we need to investigate.
+
+If you find an Issue that addresses the problem you're having, please add your own reproduction information to the existing issue rather than creating a new one. Adding a [reaction](https://github.blog/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) can also help be indicating to our maintainers that a particular problem is affecting more than just the reporter.
+
+### Pull Requests
+
+PRs to our libraries are always welcome and can be a quick way to get your fix or improvement slated for the next release. In general, PRs should:
+
+* Only fix/add the functionality in question **OR** address wide-spread whitespace/style issues, not both.
+
+* Add unit or integration tests for fixed or changed functionality (if a test suite already exists).
+
+* Address a single concern in the least number of changed lines as possible.
+
+* Include documentation in the repo or whereever applicable.
+
+* Be accompanied by a complete Pull Request template (loaded automatically when a PR is created).
+
+For changes that address core functionality or would require breaking changes (e.g. a major release), it's best to open an Issue to discuss your proposal first. This is not required but can save time creating and reviewing changes.
+
+In general, we follow the ["fork-and-pull" Git workflow](https://github.com/susam/gitpr)
+
+1. Fork the repository to your own Github account
+2. Clone the project to your machine
+3. Create a branch locally with a succinct but descriptive name
+4. Commit changes to the branch
+5. Following any formatting and testing guidelines specific to this repo
+6. Push changes to your fork
+7. Open a PR in our repository and follow the PR template so that we can efficiently review the changes.
+
+## Getting Help
+
+Join us in the [developersIndia subreddit](https://www.reddit.com/r/developersIndia) and post your question there in the correct category with a descriptive tag.
+
+<!-- End of CONTRIBUTING.md -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Reading and following these guidelines will help us make the contribution proces
 
 ## Code of Conduct
 
-We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/.github//blob/main/CODE_OF_CONDUCT.md).
+We take our open source community seriously and hold ourselves and other contributors to high standards of communication. By participating and contributing to this project, you agree to uphold our [Code of Conduct](https://github.com/developersindia/.github/blob/main/CODE_OF_CONDUCT.md).
 
 ## Getting Started
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+<!-- Begin developersIndia GitHub Org's SECURITY.md Policy v-1.0.1 -->
+
+# Security
+
+At [developersIndia](https://github.com/developersIndia) we take the security of our community-maintained Free & Open-Source Software (FOSS) seriously, which includes all source code repositories managed through our GitHub organizations.
+
+If you believe you have found a security vulnerability in any developersIndia-maintained repository that look like a breach of a security vulnerability to you, please report it to us as described below.
+
+## Reporting Security Issues
+
+Each project maintained under the developersIndia GitHub Org banner has it own specific repository hosted on GitHub. And each of those repositories has it's Issue/Discussion enabled to promote community discussions, further product enhancements, bug reports, etc within the community. As such we request you to utilize that platform to report any security vulnerability as well.
+
+Please include the requested information listed below (as much as you can provide) to help us better understand the nature and scope of the possible issue:
+
+- Type of issue (e.g. buffer overflow, SQL injection, cross-site scripting, etc.)
+- Full paths of source file(s) related to the manifestation of the issue
+- The location of the affected source code (tag/branch/commit or direct URL)
+- Any special configuration required to reproduce the issue
+- Step-by-step instructions to reproduce the issue
+- Proof-of-concept or exploit code (if possible)
+- Impact of the issue, including how an attacker might exploit the issue
+
+This information will help us triage your report more quickly.
+
+## Preferred Languages
+
+We prefer all communications on GitHub to be in English. If you're comfortable communicating in a language other than English & one which is widely spoken across the Indian subcontinent, please reach out to the maintainers of the respectic projects and/or the moderators of either the Discord/Reddit platforms.
+
+<!-- END MICROSOFT SECURITY.MD BLOCK -->

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,25 @@
+<!-- Start of SUPPORT.md file v0.0.1 -->
+
+# developersIndia Community Support
+
+## Finding Support
+
+Almost all projects maintained by the [developersIndia GitHub Org](https://github.com/developersIndia) are community maintained. So, if you need help for using a specific project or want to start contributing to it, feel free to discuss about it. Our [developersIndia subreddit](https://www.reddit.com/r/developersIndia) is open to all & join our [Discord server](https://discord.gg/b4YYdyYBGH) for closed community banter.
+
+If you found a bug in any of the community maintained projects under the developersIndia banner, please report it to the respective project repository by either opening a Issue/Discussion thread. Be sure to read the [Security Policy](https://github.com/developersIndia/.github/blob/main/SECURITY.md) before reporting the security concerns.
+
+Or if you would like to contribute to any of the community maintained projects under the developersIndia banner, please refer to the [Contributing guidelines](https://github.com/developersIndia/.github/blob/main/CONTRIBUTING.md) before opening a PR or a feature request.
+
+## Supported Versions
+
+Most if not all projects maintained under the developersIndia banner will follow some sort of version system (like [semver](https://semver.org/)) which will be duly noted in the documentations of all respective projects. Versioning projects under a specific standard helps not only the user but the maintainer of the projects to triage & fix bugs/issues in that specific version of the software.
+
+As such, please ensure to enter every detail of the issues/bug you're facing with the version details when opening or discussing in Issue/Discussion threads.
+
+## Supported Platforms
+
+If you're a project maintainer under the developersIndia community banner, please ensure your project's documentation lists the "_supported platforms_" in the docs properly. And if you're a user of the project, please refer to the respective repository's "_supported sections_" for more info.
+
+If you feel a project is missing support for a specific platform, please reach out to the project maintainer for further notice & assisstance.
+
+<!-- End of SUPPORT.md file -->


### PR DESCRIPTION
## Description

It's possible to include ["default" community health files](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file) which could be used across the developersIndia GitHub organization. Some of such files have already been created & added as tracked in #8 & this PR adds the remaining ones, namely;

- `SUPPORT.md` takes inspiration from [Electon's Support Guidelines](https://raw.githubusercontent.com/electron/electron/main/docs/tutorial/support.md).
- `CONTRIBUTING.md` takes inspiration from [Auth0's](https://raw.githubusercontent.com/auth0/open-source-template/master/GENERAL-CONTRIBUTING.md) & [Mozilla's](https://mozillascience.github.io/working-open-workshop/contributing/) Contribution guidelines.
- `SECURITY.md` takes inspiration from [Microsoft's Security Reporting policies](https://raw.githubusercontent.com/Azure/aml-template/master/SECURITY.md).

Closes #8 
